### PR TITLE
[NEW] Room pinned messages

### DIFF
--- a/rocketchat-common/src/main/java/com/rocketchat/common/data/model/BaseMessage.java
+++ b/rocketchat-common/src/main/java/com/rocketchat/common/data/model/BaseMessage.java
@@ -54,20 +54,18 @@ public abstract class BaseMessage {
     public abstract String message();
 
     @Json(name = "ts")
-    public abstract @Timestamp
-    Long timestamp();
+    public abstract String timestamp();
 
     @Json(name = "u")
     @Nullable
     public abstract User sender();
 
     @Json(name = "_updatedAt")
-    public abstract @Timestamp
-    Long updatedAt();
+    @Nullable
+    public abstract String updatedAt();
 
     @Nullable
-    public abstract @Timestamp
-    Long editedAt();
+    public abstract String editedAt();
 
     @Nullable
     public abstract User editedBy();

--- a/rocketchat-core/src/main/java/com/rocketchat/core/ChatRoom.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/ChatRoom.java
@@ -82,6 +82,32 @@ public class ChatRoom {
     }
 
     /**
+     * Gets the room pinned message list.
+     *
+     * <p>Example of expected usage:
+     *
+     * <blockquote><pre>
+     * room.getPinnedMessages(0, new PaginatedCallback() {
+     *     public void onSuccess(List list, int total) {
+     *         // Handle the pinned message list and the total of pinned messages in the room (this is not the pinned message list size).
+     *     }
+     *
+     *     public void onError(RocketChatException error) {
+     *        // Handle the error like showing a message to the user
+     *     }
+     * });
+     * </pre></blockquote>
+     *
+     * @param offset The number of items to “skip” in the query, is zero based so it starts off at 0 being the first item.
+     * @param callback The paginated callback.
+     * @see BaseRoom
+     * @since 0.8.0
+     */
+    public void getPinnedMessages(int offset, PaginatedCallback callback) {
+        client.getRoomPinnedMessages(room.roomId(), room.type(), offset, callback);
+    }
+
+    /**
      * Gets the room file list.
      *
      * <p>Example of expected usage:

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
@@ -14,17 +14,20 @@ import com.rocketchat.common.utils.Logger;
 import com.rocketchat.common.utils.Sort;
 import com.rocketchat.core.callback.LoginCallback;
 import com.rocketchat.core.callback.ServerInfoCallback;
+import com.rocketchat.core.model.Message;
 import com.rocketchat.core.model.Token;
 import com.rocketchat.core.model.attachment.Attachment;
 import com.rocketchat.core.provider.TokenProvider;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -223,9 +226,11 @@ class RestImpl {
                     JSONObject json = new JSONObject(response.body().string());
                     logger.info("Response = " + json.toString());
 
-                    // TODO Parse
+                    Type type = Types.newParameterizedType(List.class, Message.class);
+                    JsonAdapter<List<Message>> adapter = moshi.adapter(type);
+                    List<Message> messageList = adapter.fromJson(json.getJSONArray("messages").toString());
 
-//                    callback.onSuccess(messages, json.optInt("total"));
+                    callback.onSuccess(messageList, json.optInt("total"));
                 } catch (JSONException e) {
                     callback.onError(new RocketChatInvalidResponseException(e.getMessage(), e));
                 }

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
@@ -188,9 +188,49 @@ class RestImpl {
 
     }
 
-    // TODO
-    void getRoomPinnedMessages() {
+    void getRoomPinnedMessages(String roomId,
+                               BaseRoom.RoomType roomType,
+                               int offset,
+                               final PaginatedCallback callback) {
+        checkNotNull(roomId,"roomId == null");
+        checkNotNull(roomType,"roomType == null");
+        checkNotNull(callback,"callback == null");
 
+        HttpUrl httpUrl = requestUrl(baseUrl, getRestApiMethodNameByRoomType(roomType, "messages"))
+                .addQueryParameter("roomId", roomId)
+                .addQueryParameter("offset", String.valueOf(offset))
+                .addQueryParameter("query", "{\"pinned\":true}")
+                .build();
+
+        Request request = requestBuilder(httpUrl)
+                .get()
+                .build();
+
+        client.newCall(request).enqueue(new okhttp3.Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                callback.onError(new RocketChatNetworkErrorException("network error", e));
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                if (!response.isSuccessful()) {
+                    processCallbackError(response, callback);
+                    return;
+                }
+
+                try {
+                    JSONObject json = new JSONObject(response.body().string());
+                    logger.info("Response = " + json.toString());
+
+                    // TODO Parse
+
+//                    callback.onSuccess(messages, json.optInt("total"));
+                } catch (JSONException e) {
+                    callback.onError(new RocketChatInvalidResponseException(e.getMessage(), e));
+                }
+            }
+        });
     }
 
     void getRoomFiles(String roomId,

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RocketChatClient.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RocketChatClient.java
@@ -165,9 +165,11 @@ public class RocketChatClient {
 
     }
 
-    // TODO
-    public void getRoomPinnedMessages() {
-
+    public void getRoomPinnedMessages(String roomId,
+                                      BaseRoom.RoomType roomType,
+                                      int offset,
+                                      final PaginatedCallback callback) {
+        restImpl.getRoomPinnedMessages(roomId, roomType, offset, callback);
     }
 
     public void getRoomFiles(String roomId,


### PR DESCRIPTION
This PR adds the method to get the pinned message list from a room (via REST API).
Closes #36 

- [x] API request -> get room pinned message list and the total of pinned messages of a room.
     - [x] For Public channels.
     - [x] For Private Channels
     - [x] For One-to-One Channels
     - [x] For Livechat 
- [x] Pagination support.
- [x] Unit tests.