### PR TITLE
[NEW] Room favorite messages.

### DIFF
--- a/rocketchat-common/src/main/java/com/rocketchat/common/data/model/BaseMessage.java
+++ b/rocketchat-common/src/main/java/com/rocketchat/common/data/model/BaseMessage.java
@@ -54,16 +54,14 @@ public abstract class BaseMessage {
     public abstract String message();
 
     @Json(name = "ts")
-    public abstract @Timestamp
-    Long timestamp();
+    public abstract String timestamp();
 
     @Json(name = "u")
     @Nullable
     public abstract User sender();
 
     @Json(name = "_updatedAt")
-    public abstract @Timestamp
-    Long updatedAt();
+    public abstract String updatedAt();
 
     @Nullable
     public abstract @Timestamp

--- a/rocketchat-core/src/main/java/com/rocketchat/core/ChatRoom.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/ChatRoom.java
@@ -82,6 +82,32 @@ public class ChatRoom {
     }
 
     /**
+     * Gets the room favorite message list.
+     *
+     * <p>Example of expected usage:
+     *
+     * <blockquote><pre>
+     * room.getFavoriteMessages(0, new PaginatedCallback() {
+     *     public void onSuccess(List list, int total) {
+     *         // Handle the favorite message list and the total of favorite messages in the room (this is not the favorite message list size).
+     *     }
+     *
+     *     public void onError(RocketChatException error) {
+     *        // Handle the error like showing a message to the user
+     *     }
+     * });
+     * </pre></blockquote>
+     *
+     * @param offset The number of items to “skip” in the query, is zero based so it starts off at 0 being the first item.
+     * @param callback The paginated callback.
+     * @see BaseRoom
+     * @since 0.8.0
+     */
+    public void getFavoriteMessages(int offset, PaginatedCallback callback) {
+        client.getRoomFavoriteMessages(room.roomId(), room.type(), offset, callback);
+    }
+
+    /**
      * Gets the room file list.
      *
      * <p>Example of expected usage:

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
@@ -187,7 +187,8 @@ class RestImpl {
                                  BaseRoom.RoomType roomType,
                                  int offset,
                                  final PaginatedCallback callback) {
-        checkNotNull(tokenProvider, "token == null");
+        String userId = tokenProvider.getToken().getUserId();
+        checkNotNull(userId, "userId == null");
         checkNotNull(roomId, "roomId == null");
         checkNotNull(roomType, "roomType == null");
         checkNotNull(callback, "callback == null");
@@ -195,7 +196,7 @@ class RestImpl {
         HttpUrl httpUrl = requestUrl(baseUrl, getRestApiMethodNameByRoomType(roomType, "messages"))
                 .addQueryParameter("roomId", roomId)
                 .addQueryParameter("offset", String.valueOf(offset))
-                .addQueryParameter("query", "{\"starred._id\":{\"$in\":[\"" + tokenProvider.getToken().getUserId() + "\"]}}")
+                .addQueryParameter("query", "{\"starred._id\":{\"$in\":[\"" + userId + "\"]}}")
                 .build();
 
         Request request = requestBuilder(httpUrl)

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
@@ -14,17 +14,20 @@ import com.rocketchat.common.utils.Logger;
 import com.rocketchat.common.utils.Sort;
 import com.rocketchat.core.callback.LoginCallback;
 import com.rocketchat.core.callback.ServerInfoCallback;
+import com.rocketchat.core.model.Message;
 import com.rocketchat.core.model.Token;
 import com.rocketchat.core.model.attachment.Attachment;
 import com.rocketchat.core.provider.TokenProvider;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -220,9 +223,12 @@ class RestImpl {
                     JSONObject json = new JSONObject(response.body().string());
                     logger.info("Response = " + json.toString());
 
-                    // TODO Parse
+                    Type type = Types.newParameterizedType(List.class, Message.class);
+                    JsonAdapter<List<Message>> adapter = moshi.adapter(type);
+                    // TODO fix: Exception in thread "OkHttp Dispatcher" com.squareup.moshi.JsonDataException: com.squareup.moshi.JsonDataException: Expected BEGIN_OBJECT but was STRING at path $[0]._updatedAt at $[0]._updatedAt
+                    List<Message> messageList = adapter.fromJson(json.getJSONArray("messages").toString());
 
-//                     callback.onSuccess(messages, json.optInt("total"));
+                     callback.onSuccess(messageList, json.optInt("total"));
                 } catch (JSONException e) {
                     callback.onError(new RocketChatInvalidResponseException(e.getMessage(), e));
                 }

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
@@ -45,7 +45,6 @@ class RestImpl {
     private final TokenProvider tokenProvider;
     private final Moshi moshi;
     private final Logger logger;
-    private Token token;
 
     RestImpl(OkHttpClient client, Moshi moshi, HttpUrl baseUrl, TokenProvider tokenProvider, Logger logger) {
         this.client = client;
@@ -188,6 +187,7 @@ class RestImpl {
                                  BaseRoom.RoomType roomType,
                                  int offset,
                                  final PaginatedCallback callback) {
+        checkNotNull(tokenProvider, "token == null");
         checkNotNull(roomId, "roomId == null");
         checkNotNull(roomType, "roomType == null");
         checkNotNull(callback, "callback == null");
@@ -195,7 +195,7 @@ class RestImpl {
         HttpUrl httpUrl = requestUrl(baseUrl, getRestApiMethodNameByRoomType(roomType, "messages"))
                 .addQueryParameter("roomId", roomId)
                 .addQueryParameter("offset", String.valueOf(offset))
-                .addQueryParameter("query", "{\"starred._id\":{\"\\$in\":[\"" + token.getUserId() + "\"]}}")
+                .addQueryParameter("query", "{\"starred._id\":{\"$in\":[\"" + tokenProvider.getToken().getUserId() + "\"]}}")
                 .build();
 
         Request request = requestBuilder(httpUrl)
@@ -221,7 +221,7 @@ class RestImpl {
 
                     // TODO Parse
 
-                    // callback.onSuccess(messages, json.optInt("total"));
+//                     callback.onSuccess(messages, json.optInt("total"));
                 } catch (JSONException e) {
                     callback.onError(new RocketChatInvalidResponseException(e.getMessage(), e));
                 }
@@ -333,7 +333,7 @@ class RestImpl {
                 .url(httpUrl);
 
         if (tokenProvider != null && tokenProvider.getToken() != null) {
-            token = tokenProvider.getToken();
+            Token token = tokenProvider.getToken();
             builder.addHeader("X-Auth-Token", token.getAuthToken())
                     .addHeader("X-User-Id", token.getUserId());
         }

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RestImpl.java
@@ -225,7 +225,6 @@ class RestImpl {
 
                     Type type = Types.newParameterizedType(List.class, Message.class);
                     JsonAdapter<List<Message>> adapter = moshi.adapter(type);
-                    // TODO fix: Exception in thread "OkHttp Dispatcher" com.squareup.moshi.JsonDataException: com.squareup.moshi.JsonDataException: Expected BEGIN_OBJECT but was STRING at path $[0]._updatedAt at $[0]._updatedAt
                     List<Message> messageList = adapter.fromJson(json.getJSONArray("messages").toString());
 
                      callback.onSuccess(messageList, json.optInt("total"));

--- a/rocketchat-core/src/main/java/com/rocketchat/core/RocketChatClient.java
+++ b/rocketchat-core/src/main/java/com/rocketchat/core/RocketChatClient.java
@@ -160,9 +160,11 @@ public class RocketChatClient {
 
     }
 
-    // TODO
-    public void getRoomFavoriteMessages() {
-
+    public void getRoomFavoriteMessages(String roomId,
+                                        BaseRoom.RoomType roomType,
+                                        int offset,
+                                        final PaginatedCallback callback) {
+        restImpl.getRoomFavoriteMessages(roomId, roomType, offset, callback);
     }
 
     // TODO

--- a/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
+++ b/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.timeout;
@@ -123,6 +124,7 @@ public class RestImplTest {
                 .once();
 
         rest.signin("user", "password", loginCallback);
+
         verify(loginCallback, timeout(DEFAULT_TIMEOUT).only())
                 .onError(exceptionCaptor.capture());
 
@@ -144,6 +146,7 @@ public class RestImplTest {
 
         verify(loginCallback, timeout(DEFAULT_TIMEOUT).only())
                 .onError(exceptionCaptor.capture());
+
         RocketChatException exception = exceptionCaptor.getValue();
         assertThat(exception, is(instanceOf(RocketChatAuthException.class)));
         assertThat(exception.getMessage(), is(equalTo("Unauthorized")));
@@ -155,6 +158,7 @@ public class RestImplTest {
 
         verify(loginCallback, timeout(DEFAULT_TIMEOUT).only())
                 .onError(exceptionCaptor.capture());
+
         RocketChatException exception = exceptionCaptor.getValue();
         assertThat(exception, is(instanceOf(RocketChatException.class)));
 
@@ -203,6 +207,7 @@ public class RestImplTest {
                 .once();
 
         rest.getRoomFiles("general", BaseRoom.RoomType.PUBLIC, 0, Attachment.SortBy.UPLOADED_DATE, Sort.DESC, paginatedCallback);
+
         verify(paginatedCallback, timeout(100).only())
                 .onError(exceptionCaptor.capture());
 
@@ -212,7 +217,6 @@ public class RestImplTest {
     }
 
     @Test
-    //TODO Needs to know why it is failing.
     public void testGetRoomFilesShouldBeSuccessful() {
         mockServer.expect()
                 .get()

--- a/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
+++ b/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
@@ -51,8 +51,7 @@ public class RestImplTest {
     @Mock private LoginCallback loginCallback;
     @Mock private PaginatedCallback paginatedCallback;
     @Captor private ArgumentCaptor<Token> tokenCaptor;
-    @Captor private ArgumentCaptor<List<Attachment>> attachmentsCaptor;
-    @Captor private ArgumentCaptor<List<Message>> messagesCaptor;
+    @Captor private ArgumentCaptor<List> listCaptor;
     @Captor private ArgumentCaptor<RocketChatException> exceptionCaptor;
     
     private static final int DEFAULT_TIMEOUT = 200;
@@ -260,9 +259,9 @@ public class RestImplTest {
         rest.getRoomFiles("GENERAL", BaseRoom.RoomType.PUBLIC, 0, Attachment.SortBy.UPLOADED_DATE, Sort.DESC, paginatedCallback);
 
         verify(paginatedCallback, timeout(DEFAULT_TIMEOUT).only())
-                .onSuccess(attachmentsCaptor.capture(), anyInt());
+                .onSuccess(listCaptor.capture(), anyInt());
 
-        List<Attachment> attachmentList = attachmentsCaptor.getValue();
+        List<Attachment> attachmentList = listCaptor.getValue();
         assertThat(attachmentList, is(notNullValue()));
         assertThat(attachmentList.size(), is(equalTo(1)));
         Attachment attachment = attachmentList.get(0);
@@ -350,9 +349,9 @@ public class RestImplTest {
         rest.getRoomFavoriteMessages("GENERAL", BaseRoom.RoomType.PUBLIC, 0, paginatedCallback);
 
         verify(paginatedCallback, timeout(DEFAULT_TIMEOUT).only())
-                .onSuccess(attachmentsCaptor.capture(), anyInt());
+                .onSuccess(listCaptor.capture(), anyInt());
 
-        List<Message> messageList = messagesCaptor.getValue();
+        List<Message> messageList = listCaptor.getValue();
         assertThat(messageList, is(notNullValue()));
         assertThat(messageList.size(), is(equalTo(1)));
         Message message = messageList.get(0);

--- a/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
+++ b/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
@@ -48,9 +48,10 @@ public class RestImplTest {
     private DefaultMockServer mockServer;
     @Mock private TokenProvider tokenProvider;
     @Mock private LoginCallback loginCallback;
-    @Mock private PaginatedCallback<Attachment> paginatedCallback;
+    @Mock private PaginatedCallback paginatedCallback;
     @Captor private ArgumentCaptor<Token> tokenCaptor;
     @Captor private ArgumentCaptor<List<Attachment>> attachmentsCaptor;
+    @Captor private ArgumentCaptor<List<Message>> messagesCaptor;
     @Captor private ArgumentCaptor<RocketChatException> exceptionCaptor;
     
     private static final int DEFAULT_TIMEOUT = 200;
@@ -259,6 +260,7 @@ public class RestImplTest {
 
         verify(paginatedCallback, timeout(DEFAULT_TIMEOUT).only())
                 .onSuccess(attachmentsCaptor.capture(), anyInt());
+
         List<Attachment> attachmentList = attachmentsCaptor.getValue();
         assertThat(attachmentList, is(notNullValue()));
         assertThat(attachmentList.size(), is(equalTo(1)));
@@ -266,4 +268,29 @@ public class RestImplTest {
         assertThat(attachment.getId(), is(equalTo("B5HXEJQvoqXjfMyKD")));
         assertThat(attachment.getName(), is(equalTo("sample.txt")));
     }
+
+    //     _____ ______ _______     _____   ____   ____  __  __        ______ __      ______  _____  _____ _______ ______      __  __ ______  _____ _____         _____ ______  _____   _______ ______  _____ _______ _____
+    //    / ____|  ____|__   __|   |  __ \ / __ \ / __ \|  \/  |      |  ____/\ \    / / __ \|  __ \|_   _|__   __|  ____|    |  \/  |  ____|/ ____/ ____|  /\   / ____|  ____|/ ____| |__   __|  ____|/ ____|__   __/ ____|
+    //   | |  __| |__     | |______| |__) | |  | | |  | | \  / |______| |__ /  \ \  / / |  | | |__) | | |    | |  | |__ ______| \  / | |__  | (___| (___   /  \ | |  __| |__  | (___      | |  | |__  | (___    | | | (___
+    //   | | |_ |  __|    | |______|  _  /| |  | | |  | | |\/| |______|  __/ /\ \ \/ /| |  | |  _  /  | |    | |  |  __|______| |\/| |  __|  \___ \\___ \ / /\ \| | |_ |  __|  \___ \     | |  |  __|  \___ \   | |  \___ \
+    //   | |__| | |____   | |      | | \ \| |__| | |__| | |  | |      | | / ____ \  / | |__| | | \ \ _| |_   | |  | |____     | |  | | |____ ____) |___) / ____ \ |__| | |____ ____) |    | |  | |____ ____) |  | |  ____) |
+    //    \_____|______|  |_|      |_|  \_\\____/ \____/|_|  |_|      |_|/_/    \_\/   \____/|_|  \_\_____|  |_|  |______|    |_|  |_|______|_____/_____/_/    \_\_____|______|_____/     |_|  |______|_____/   |_| |_____/
+    //
+    //
+
+    @Test(expected = NullPointerException.class)
+    public void testGetFavoriteMessagesShouldFailWithNullRoomId() {
+        rest.getRoomFavoriteMessages(null, BaseRoom.RoomType.PUBLIC, 0, paginatedCallback);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetRoomFavoriteMessagesShouldFailWithNullRoomType() {
+        rest.getRoomFavoriteMessages("roomId", null, 0, paginatedCallback);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetRoomFavoriteMessagesShouldFailWithNullCallback() {
+        rest.getRoomFavoriteMessages("roomId", BaseRoom.RoomType.PUBLIC, 0, null);
+    }
+    
 }

--- a/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
+++ b/rocketchat-core/src/test/java/com/rocketchat/core/RestImplTest.java
@@ -48,7 +48,6 @@ public class RestImplTest {
     private RestImpl rest;
     private DefaultMockServer mockServer;
     @Mock private TokenProvider tokenProvider;
-    @Mock private Token token;
     @Mock private LoginCallback loginCallback;
     @Mock private PaginatedCallback paginatedCallback;
     @Captor private ArgumentCaptor<Token> tokenCaptor;


### PR DESCRIPTION
This PR adds the method to get the favorite message list from a room (via REST API).
Closes #35 

- [x] API request -> get room favorite message list and the total of favorite messages of a room.
     - [x] For Public channels.
     - [x] For Private Channels
     - [x] For One-to-One Channels
     - [x] For Livechat 
- [x] Pagination support.
- [x] Unit tests.
