### PR TITLE
Changed a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ Features
 All docs are available under **docs/** directory on the repo.
 
 #### Demo Android App
-- **Android app based on Java SDK can be found here** => [Demo Android App based on SDK](https://github.com/RocketChat/RocketChat-Android-Demo)
+- **Android app based on Java SDK can be found here** => [Demo Android App based on SDK](https://github.com/sacOO7/RocketChat-Android-Demo)


### PR DESCRIPTION
Broken link for android demo of rocket.chat app was not working and showing error 404 . Thus, changed.